### PR TITLE
Minor Fixes/Additions for MMW

### DIFF
--- a/src/models/legend.js
+++ b/src/models/legend.js
@@ -19,6 +19,7 @@ nv.models.legend = function() {
         , expanded = false
         , dispatch = d3.dispatch('legendClick', 'legendDblclick', 'legendMouseover', 'legendMouseout', 'stateChange')
         , vers = 'classic' //Options are "classic" and "furious"
+        , reverse = false
         ;
 
     function chart(selection) {
@@ -178,13 +179,13 @@ nv.models.legend = function() {
                 var seriesWidths = [];
                 series.each(function(d,i) {
                     var legendText;
-                    if (getKey(d).length > maxKeyLength) { 
+                    if (getKey(d).length > maxKeyLength) {
                         var trimmedKey = getKey(d).substring(0, maxKeyLength);
                         legendText = d3.select(this).select('text').text(trimmedKey + "...");
                         d3.select(this).append("svg:title").text(getKey(d));
                     } else {
                         legendText = d3.select(this).select('text');
-                    } 
+                    }
                     var nodeTextLength;
                     try {
                         nodeTextLength = legendText.node().getComputedTextLength();
@@ -229,7 +230,8 @@ nv.models.legend = function() {
                 }
 
                 series
-                    .attr('transform', function(d, i) {
+                    .attr('transform', function(d, j) {
+                        var i = reverse ? (seriesText[0].length - j - 1) : j;
                         return 'translate(' + xPositions[i % seriesPerRow] + ',' + (5 + Math.floor(i / seriesPerRow) * versPadding) + ')';
                     });
 
@@ -360,6 +362,7 @@ nv.models.legend = function() {
         radioButtonMode:    {get: function(){return radioButtonMode;}, set: function(_){radioButtonMode=_;}},
         expanded:   {get: function(){return expanded;}, set: function(_){expanded=_;}},
         vers:   {get: function(){return vers;}, set: function(_){vers=_;}},
+        reverse:    {get: function(){return reverse;}, set: function(_){reverse=_;}},
 
         // options that require extra logic in the setter
         margin: {get: function(){return margin;}, set: function(_){

--- a/src/models/legend.js
+++ b/src/models/legend.js
@@ -20,6 +20,7 @@ nv.models.legend = function() {
         , dispatch = d3.dispatch('legendClick', 'legendDblclick', 'legendMouseover', 'legendMouseout', 'stateChange')
         , vers = 'classic' //Options are "classic" and "furious"
         , reverse = false
+        , disableToggle = false
         ;
 
     function chart(selection) {
@@ -94,12 +95,15 @@ nv.models.legend = function() {
 
             series
                 .on('mouseover', function(d,i) {
+                    if (disableToggle) { return; }
                     dispatch.legendMouseover(d,i);  //TODO: Make consistent with other event objects
                 })
                 .on('mouseout', function(d,i) {
+                    if (disableToggle) { return; }
                     dispatch.legendMouseout(d,i);
                 })
                 .on('click', function(d,i) {
+                    if (disableToggle) { return; }
                     dispatch.legendClick(d,i);
                     // make sure we re-get data in case it was modified
                     var data = series.data();
@@ -145,6 +149,7 @@ nv.models.legend = function() {
                     }
                 })
                 .on('dblclick', function(d,i) {
+                    if (disableToggle) { return; }
                     if(vers == 'furious' && expanded) return;
                     dispatch.legendDblclick(d,i);
                     if (updateState) {
@@ -363,6 +368,7 @@ nv.models.legend = function() {
         expanded:   {get: function(){return expanded;}, set: function(_){expanded=_;}},
         vers:   {get: function(){return vers;}, set: function(_){vers=_;}},
         reverse:    {get: function(){return reverse;}, set: function(_){reverse=_;}},
+        disableToggle: {get: function(){return disableToggle;}, set: function(_){disableToggle=_;}},
 
         // options that require extra logic in the setter
         margin: {get: function(){return margin;}, set: function(_){

--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -243,6 +243,10 @@ nv.models.multiBarChart = function() {
                         .attr("transform", function(d,i) {
                             return getTranslate(0, (i === 0 || totalInBetweenTicks % 2 !== 0) ? staggerDown : staggerUp);
                         });
+                } else if (!staggerLabels) {
+                    xTicks
+                        .selectAll("text")
+                        .attr('transform', null);
                 }
 
                 if (wrapLabels) {


### PR DESCRIPTION
This patch change set contains a few minor fixes and additions for Model My Watershed.
- It is now possible to disable the clickability of items in a chart legend.
- It is now possible to reverse the order in which items are listed in a chart legend.
- transformation left on x-axis label elements are now removed when there is `staggerLabels` is set to false on a `multiBarChart`.
