### PR TITLE
Deduplicate vertices to fix Voronoi rendering

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -203,6 +203,19 @@ nv.models.scatter = function() {
                         [width + 10,-10]
                     ]);
 
+                    // Taken from https://github.com/novus/nvd3/pull/584
+                    // delete duplicates from vertices - essential assumption for d3.geom.voronoi
+                    var epsilon = 1e-6; // d3 uses 1e-6 to determine equivalence.
+                    vertices = vertices.sort(function(a,b){return ((a[0] - b[0]) || (a[1] - b[1]))});
+                    for (var i = 0; i < vertices.length - 1; ) {
+                        if ((Math.abs(vertices[i][0] - vertices[i+1][0]) < epsilon) &&
+                            (Math.abs(vertices[i][1] - vertices[i+1][1]) < epsilon)) {
+                            vertices.splice(i+1, 1);
+                        } else {
+                            i++;
+                        }
+                    }
+
                     var voronoi = d3.geom.voronoi(vertices).map(function(d, i) {
                         return {
                             'data': bounds.clip(d),


### PR DESCRIPTION
## Overview

Voronoi rendering assumes distinct vertices. When this is not the case, such as for line charts with multiple series having identical values (think Current Conditions and an Unmodified Scenario in MMW), we get errors. This issue was seen by multiple people (see https://github.com/novus/nvd3/issues/330), and fixed in https://github.com/novus/nvd3/pull/584. We adopt that fix for our shim here.

Connects https://github.com/WikiWatershed/model-my-watershed/issues/2928